### PR TITLE
Fix "Invalid UUID string" crash

### DIFF
--- a/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
@@ -633,7 +633,7 @@ public class EntityRat extends EntityTameable implements IAnimatedEntity {
         if (compound.hasKey("CustomName", 8)) {
             this.setCustomNameTag(compound.getString("CustomName"));
         }
-        if (compound.hasKey("MonsterOwnerUUID", 8)) {
+        if (compound.hasKey("MonsterOwnerUUID", 8) && !compound.getString("MonsterOwnerUUID").equals("")) {
             String s = compound.getString("MonsterOwnerUUID");
             this.setMonsterOwnerId(UUID.fromString(s));
             this.setOwnerMonster(true);

--- a/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
@@ -857,7 +857,7 @@ public class EntityRat extends EntityTameable implements IAnimatedEntity {
     @Override
     public void onLivingUpdate() {
         this.setRatStatus(RatStatus.IDLE);
-        if (this.getUpgradeSlot() != prevUpgrade) {
+        if (!ItemStack.areItemsEqual(this.getUpgradeSlot(), prevUpgrade)) {
             this.onUpgradeChanged();
         }
         super.onLivingUpdate();


### PR DESCRIPTION
There is a problem with the way UUID is handled: when saving, if there's none, it gets converted to an empty string, which isn't a valid UUID representation. Thus, when loading the NBT data, it throws an exception such as this one:

```
java.util.concurrent.ExecutionException: net.minecraft.util.ReportedException: Loading entity NBT
    at java.util.concurrent.FutureTask.report(FutureTask.java:122)
    at java.util.concurrent.FutureTask.get(FutureTask.java:192)
    at net.minecraft.util.Util.runTask(Util.java:531)
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:723)
    at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:668)
    at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:279)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
    at java.lang.Thread.run(Thread.java:748)
Caused by: net.minecraft.util.ReportedException: Loading entity NBT
    at net.minecraft.entity.Entity.readFromNBT(Entity.java:1878)
    at net.minecraft.item.ItemMonsterPlacer.applyItemEntityDataToEntity(ItemMonsterPlacer.java:157)
    at net.minecraft.item.ItemMonsterPlacer.onItemUse(ItemMonsterPlacer.java:104)
    at net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(ForgeHooks.java:889)
    at net.minecraft.item.ItemStack.onItemUse(ItemStack.java:186)
    at net.minecraft.server.management.PlayerInteractionManager.processRightClickBlock(PlayerInteractionManager.java:481)
    at net.minecraft.network.NetHandlerPlayServer.processTryUseItemOnBlock(NetHandlerPlayServer.java:741)
    at net.minecraft.network.play.client.CPacketPlayerTryUseItemOnBlock.processPacket(SourceFile:55)
    at net.minecraft.network.play.client.CPacketPlayerTryUseItemOnBlock.processPacket(SourceFile:11)
    at net.minecraft.network.PacketThreadUtil$1.run(PacketThreadUtil.java:22)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at net.minecraft.util.Util.runTask(Util.java:529)
    ... 5 more
Caused by: java.lang.IllegalArgumentException: Invalid UUID string: 
    at java.util.UUID.fromString(UUID.java:194)
    at com.github.alexthe666.rats.server.entity.EntityRat.readEntityFromNBT(EntityRat.java:638)
    at net.minecraft.entity.Entity.readFromNBT(Entity.java:1866)
    ... 17 more
```