### PR TITLE
Fix a bug where replanting crops would duplicate seeds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
   }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
-version = "3.2.11-1.12.2"
+version = "3.2.12-1.12.2"
 group= "rats"
 archivesBaseName = "rats"
 sourceCompatibility = targetCompatibility = "1.8"


### PR DESCRIPTION
When rats harvest and replant crops, they don"t use any seed from the crop's drops, duplicating the dropped seeds.

However now if the crop doesn't drop any seed, the crop is not replanted, and the seed type is not checked (replanting consumes the first seed in the drop list). 