### PR TITLE
Support container changing fluid handlers

### DIFF
--- a/src/main/java/com/github/alexthe666/rats/server/events/CommonEvents.java
+++ b/src/main/java/com/github/alexthe666/rats/server/events/CommonEvents.java
@@ -422,13 +422,16 @@ public class CommonEvents {
                 event.getPlayer().playSound(SoundEvents.ITEM_BUCKET_EMPTY, 1, 1);
                 if (!event.getPlayer().isCreative()) {
                     if (event.getItemStack().getItem() == Items.MILK_BUCKET) {
-                        event.getItemStack().shrink(1);
-                        event.getPlayer().addItemStackToInventory(new ItemStack(Items.BUCKET));
+                        event.getPlayer().setHeldItem(event.getHand(), new ItemStack(Items.BUCKET));
                     } else if (RatUtils.isMilk(event.getItemStack())) {
-                        LazyOptional<IFluidHandlerItem> fluidHandler = FluidUtil.getFluidHandler(event.getItemStack());
-                        if (fluidHandler.isPresent() && fluidHandler.orElse(null) != null) {
-                            fluidHandler.orElse(null).drain(1000, IFluidHandler.FluidAction.EXECUTE);
-                        }
+                        LazyOptional<IFluidHandlerItem> fluidHandlerOptional = FluidUtil.getFluidHandler(event.getItemStack());
+                        fluidHandlerOptional.ifPresent(fluidHandler -> {
+                            fluidHandler.drain(1000, IFluidHandler.FluidAction.EXECUTE);
+                            ItemStack container = fluidHandler.getContainer();
+                            if (event.getItemStack() != container) {
+                                event.getPlayer().setHeldItem(event.getHand(), container);
+                            }
+                        });
                     }
                 }
                 event.setCanceled(true);


### PR DESCRIPTION
This PR supports fluid handlers with container stack changing during cauldron filling. Additionally after filling a cauldron with a vanilla milk bucket, the empty bucket stays in the correct hand.

My mod [Ceramic Bucket](https://github.com/cech12/CeramicBucket/issues/25) adds a custom milk bucket that uses a fluid handler where the container item is changed after emptying. This PR enables to support my mod and other mods which are using this intended mechanism.

