### PR TITLE
Fixed Mining Rat Crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.16.3-34.1.42'
+    minecraft 'net.minecraftforge:forge:1.16.4-35.1.0'
     compileOnly fg.deobf("mezz.jei:jei-1.16.2:7.1.3.19:api")
     runtimeOnly fg.deobf("mezz.jei:jei-1.16.2:7.1.3.19")
     compile 'citadel:citadel:1.4.0:deobf'

--- a/src/main/java/com/github/alexthe666/rats/server/entity/RatUtils.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/RatUtils.java
@@ -633,7 +633,7 @@ public class RatUtils {
 
     private static void destroyBlock(EntityRat entity, BlockPos pos, BlockState state) {
         if(entity.world instanceof ServerWorld){
-            LootContext.Builder loot = new LootContext.Builder((ServerWorld)entity.world).withParameter(LootParameters.TOOL, ItemStack.EMPTY).withRandom(entity.getRNG()).withLuck((float)1.0F);
+            LootContext.Builder loot = new LootContext.Builder((ServerWorld)entity.world).withParameter(LootParameters.TOOL, ItemStack.EMPTY).withParameter(LootParameters.field_237457_g_, entity.getPositionVec()).withRandom(entity.getRNG()).withLuck((float)1.0F);
             List<ItemStack> drops = state.getBlock().getDrops(state, loot);
             if (!drops.isEmpty() && entity.canRatPickupItem(drops.get(0))) {
                 for (ItemStack drop : drops) {


### PR DESCRIPTION
Fixed mining rat crash by fulfilling the [parameter minecraft:origin] on the LootContext object loot.