### PR TITLE
fix curdling machine to be able to use milk tanks of other mods

### DIFF
--- a/src/main/java/com/github/alexthe666/rats/server/blocks/BlockAutoCurdler.java
+++ b/src/main/java/com/github/alexthe666/rats/server/blocks/BlockAutoCurdler.java
@@ -80,10 +80,15 @@ public class BlockAutoCurdler extends ContainerBlock implements IUsesTEISR {
                         FluidStack drain = fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE);
                         if (drain.getAmount() > 0 || stack.getItem() == Items.MILK_BUCKET) {
                             if (te.tank.fill(fluidStack.copy(), IFluidHandler.FluidAction.SIMULATE) != 0) {
-                                te.tank.fill(fluidStack.copy(), IFluidHandler.FluidAction.EXECUTE);
+                                int amount = te.tank.fill(fluidStack.copy(), IFluidHandler.FluidAction.EXECUTE);
                                 if (!player.isCreative()) {
-                                    fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.EXECUTE);
-                                    if (stack.getItem() == Items.MILK_BUCKET) {
+                                    fluidHandler.drain(amount, IFluidHandler.FluidAction.EXECUTE);
+                                    ItemStack container = fluidHandler.getContainer();
+                                    //support container changing tanks
+                                    if (stack != container) {
+                                        stack.shrink(1);
+                                        player.addItemStackToInventory(container);
+                                    } else if (stack.getItem() == Items.MILK_BUCKET) {
                                         stack.shrink(1);
                                         player.addItemStackToInventory(new ItemStack(Items.BUCKET));
                                     }

--- a/src/main/java/com/github/alexthe666/rats/server/entity/tile/TileEntityAutoCurdler.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/tile/TileEntityAutoCurdler.java
@@ -201,17 +201,23 @@ public class TileEntityAutoCurdler extends LockableTileEntity implements ITickab
             }
 
         } else if (isMilk(curdlerStacks.get(0))) {
-            FluidStack def = null;
-            Optional<FluidStack> fluidStack = FluidUtil.getFluidContained(curdlerStacks.get(0));
-            if (fluidStack != null) {
-                IFluidHandlerItem fluidHandler = (IFluidHandlerItem) FluidUtil.getFluidHandler(curdlerStacks.get(0));
-                if (fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE) != null && fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE).getAmount() > 0) {
-                    if (tank.fill(fluidStack.orElse(def).copy(), IFluidHandler.FluidAction.SIMULATE) != 0) {
-                        tank.fill(fluidStack.orElse(def).copy(), IFluidHandler.FluidAction.EXECUTE);
-                        fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.EXECUTE);
+            Optional<FluidStack> fluidStackOptional = FluidUtil.getFluidContained(curdlerStacks.get(0));
+            fluidStackOptional.ifPresent(fluidStack -> {
+                LazyOptional<IFluidHandlerItem> fluidHandlerOptional = FluidUtil.getFluidHandler(curdlerStacks.get(0));
+                fluidHandlerOptional.ifPresent(fluidHandler -> {
+                    if (fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE).getAmount() > 0) {
+                        if (tank.fill(fluidStack.copy(), IFluidHandler.FluidAction.SIMULATE) != 0) {
+                            int amount = tank.fill(fluidStack.copy(), IFluidHandler.FluidAction.EXECUTE);
+                            fluidHandler.drain(amount, IFluidHandler.FluidAction.EXECUTE);
+                            //support container changing tanks
+                            ItemStack container = fluidHandler.getContainer();
+                            if (curdlerStacks.get(0) != container) {
+                                curdlerStacks.set(0, container);
+                            }
+                        }
                     }
-                }
-            }
+                });
+            });
         }
     }
 


### PR DESCRIPTION
This PR fixes some issues with the curdling machine when tanks of other mods are used.

- Fixes crash if a container of another mod is added to the item slot of curdling machine.
- Containers are not completly emptied when the curdling machine cannot hold the whole content.
- Tanks that are chaning their container during draning are supported.

Related issues: #477 #498 #519