### PR TITLE
Some small bugfixes for the cute little Pests

### DIFF
--- a/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
@@ -700,7 +700,7 @@ public class EntityRat extends TameableEntity implements IAnimatedEntity, IRatla
             for (int i = 0; i < nbttaglist.size(); ++i) {
                 CompoundNBT CompoundNBT = nbttaglist.getCompound(i);
                 int j = CompoundNBT.getByte("Slot") & 255;
-                if (j <= 4) {
+                if (j <= ratInventory.getSizeInventory()) {
                     ItemStack itemstack = ItemStack.read(CompoundNBT);
                     ratInventory.setInventorySlotContents(j, itemstack);
                 }

--- a/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
@@ -700,7 +700,7 @@ public class EntityRat extends TameableEntity implements IAnimatedEntity, IRatla
             for (int i = 0; i < nbttaglist.size(); ++i) {
                 CompoundNBT CompoundNBT = nbttaglist.getCompound(i);
                 int j = CompoundNBT.getByte("Slot") & 255;
-                if (j <= ratInventory.getSizeInventory()) {
+                if (j < ratInventory.getSizeInventory()) {
                     ItemStack itemstack = ItemStack.read(CompoundNBT);
                     ratInventory.setInventorySlotContents(j, itemstack);
                 }

--- a/src/main/java/com/github/alexthe666/rats/server/items/ItemGenericFood.java
+++ b/src/main/java/com/github/alexthe666/rats/server/items/ItemGenericFood.java
@@ -62,7 +62,7 @@ public class ItemGenericFood extends Item {
     }
 
     public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity LivingEntity) {
-        if (this == RatsItemRegistry.CONFIT_BYALDI || this == RatsItemRegistry.POTATO_KNISHES) {
+        if (this == RatsItemRegistry.CONFIT_BYALDI || this == RatsItemRegistry.POTATO_KNISHES || (this instanceof ItemPlagueHealer)) {
             if (LivingEntity instanceof PlayerEntity) {
                 PlayerEntity PlayerEntity = (PlayerEntity) LivingEntity;
                 PlayerEntity.getFoodStats().addStats(healAmount, saturation);

--- a/src/main/java/com/github/alexthe666/rats/server/items/ItemPlagueHealer.java
+++ b/src/main/java/com/github/alexthe666/rats/server/items/ItemPlagueHealer.java
@@ -37,7 +37,7 @@ public class ItemPlagueHealer extends ItemGenericFood {
     }
 
     public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity LivingEntity) {
-        if (stack.getItem() == RatsItemRegistry.PLAGUE_STEW) {
+        if (stack.getItem() == RatsItemRegistry.PLAGUE_STEW && stack.getCount() == 1) {
             super.onItemUseFinish(stack, worldIn, LivingEntity);
             return new ItemStack(Items.BOWL);
         } else {


### PR DESCRIPTION
- Fixed that not all Rat inventory slots get correctly loaded from NBT data. 
- ItemPlagueHealer.onFoodEaten() never gets called. Fixed in superclass ItemGenericFood.onItemUseFinish(). 
- Fixed eating of an entire stack of PLAGUE_STEW items at once and getting only 1 Items.BOWL back. Added a stack size check in ItemPlagueHealer.onItemUseFinish() to prevent it.