### PR TITLE
Fixed RAT_UPGRADE_WARRIOR in EntityRat.java

### DIFF
--- a/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/EntityRat.java
@@ -3003,7 +3003,7 @@ public class EntityRat extends TameableEntity implements IAnimatedEntity, IRatla
             flagAttack = true;
         }
         if (this.hasUpgrade(RatsItemRegistry.RAT_UPGRADE_WARRIOR)) {
-            tryIncreaseStat(Attributes.ATTACK_DAMAGE, 40D);
+            tryIncreaseStat(Attributes.MAX_HEALTH, 40D);
             tryIncreaseStat(Attributes.ATTACK_DAMAGE, 12D);
             tryIncreaseStat(Attributes.ARMOR, 10D);
             flagHealth = true;


### PR DESCRIPTION
Warrior Upgrade applies two times an increase of armor, but MAX_HEALTH needs to be set to 40 to be correct as the item description reads. 