### PR TITLE
Assorted Vegetables recipe conflict proposal

### DIFF
--- a/src/main/resources/data/rats/recipes/assorted_vegetables.json
+++ b/src/main/resources/data/rats/recipes/assorted_vegetables.json
@@ -1,15 +1,31 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "pattern": [
-    "VVV",
-    "VVV",
-    "VVV"
-  ],
-  "key": {
-    "V": {
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "forge:vegetables"
+    },
+    {
+      "tag": "forge:vegetables"
+    },
+    {
+      "tag": "forge:vegetables"
+    },
+    {
+      "tag": "forge:vegetables"
+    },
+    {
+      "tag": "forge:vegetables"
+    },
+    {
+      "tag": "forge:vegetables"
+    },
+    {
+      "tag": "forge:vegetables"
+    },
+    {
       "tag": "forge:vegetables"
     }
-  },
+  ],
   "result": {
     "item": "rats:assorted_vegetables"
   }


### PR DESCRIPTION
change proposed in: https://github.com/Alex-the-666/Rats/issues/684
changes: 8 vegetables required instead of 9 (recipe conflict), from shaped crafting to shapeless crafting (makes sense in this context)