### PR TITLE
Fix infinite replanting of lily pads and flowers

### DIFF
--- a/src/main/java/com/github/alexthe666/rats/server/entity/ai/RatAIHarvestCrops.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/ai/RatAIHarvestCrops.java
@@ -112,7 +112,7 @@ public class RatAIHarvestCrops extends Goal {
                     this.entity.fleePos = this.targetBlock;
 
                     if ((!RatConfig.ratsBreakBlockOnHarvest || entity.hasUpgrade(RatsItemRegistry.RAT_UPGRADE_REPLANTER))) {
-                        if(block.getMaterial() == Material.GOURD){
+                        if(block.getMaterial() == Material.GOURD || block.getBlock() instanceof FlowerBlock || block.getBlock() instanceof LilyPadBlock){
                             this.entity.world.destroyBlock(targetBlock, false);
                         }else{
                             this.entity.world.setBlockState(targetBlock, block.getBlock().getDefaultState());


### PR DESCRIPTION
Fixes flowers and lily pads being infinitely planted and replanted with the harvester command and replanter upgrades.
(Fixes #698 and fixes #706)