### PR TITLE
Fixed scales tag

### DIFF
--- a/src/main/resources/data/rats/recipes/dragon_wing_iaf.json
+++ b/src/main/resources/data/rats/recipes/dragon_wing_iaf.json
@@ -16,7 +16,7 @@
       "tag": "forge:bones/dragon"
     },
     "L": {
-      "tag": "#forge:scales/dragon"
+      "tag": "forge:scales/dragon"
     }
   },
   "result": {


### PR DESCRIPTION
There should not be an asterisk before this item tag, it causes a parsing issue and the recipe fails.