### PR TITLE
Disable vanilla dragon wing recipe if iceandfire is loaded

### DIFF
--- a/src/main/resources/data/rats/recipes/dragon_wing_vanilla.json
+++ b/src/main/resources/data/rats/recipes/dragon_wing_vanilla.json
@@ -1,5 +1,14 @@
 {
   "type": "minecraft:crafting_shaped",
+  "conditions": [
+    {
+      "type": "forge:not",
+      "value": {
+        "type": "forge:mod_loaded",
+        "modid": "iceandfire"
+      }
+    }
+  ],
   "pattern": [
     "BBB",
     "LLB",


### PR DESCRIPTION
Conditional statement that will only allow the recipe to load if iceandfire is not loaded. If iceandfire is loaded, then this recipe will not load, and the other recipe that uses dragon bones and scales will instead be used.