### PR TITLE
Preserve itemstack data when using platter

### DIFF
--- a/src/main/java/com/github/alexthe666/rats/server/entity/ai/goal/RatTargetItemsGoal.java
+++ b/src/main/java/com/github/alexthe666/rats/server/entity/ai/goal/RatTargetItemsGoal.java
@@ -106,7 +106,7 @@ public class RatTargetItemsGoal extends Goal {
 					int extractSize = alreadyHolding.getCount() + duplicate.getCount() < 64 ? duplicate.getCount() : Math.min(64 - alreadyHolding.getCount(), duplicate.getCount());
 					duplicate.setCount(extractSize);
 					this.targetItem.getItem().shrink(extractSize);
-					this.rat.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(duplicate.getItem(), alreadyHolding.getCount() + extractSize));
+					this.rat.setItemInHand(InteractionHand.MAIN_HAND, duplicate.copyWithCount(alreadyHolding.getCount() + extractSize));
 				} else {
 					duplicate.setCount(1);
 					this.targetItem.getItem().shrink(1);


### PR DESCRIPTION
Currently, data in ItemStack is erased when gathered up by rat with platter upgrade in use. For the player, this means rat with platter and set to gather will erase contents of shulkers, texts in written books, etc. This fixes by creating a copy if the target itemStack rather than create a new itemStack lacking the relevant tags. 